### PR TITLE
Added support for parsing metadata fields

### DIFF
--- a/data/how-to-do-great-work.md
+++ b/data/how-to-do-great-work.md
@@ -1,3 +1,9 @@
+---
+title: How to do great work
+date: 2023-07
+url: https://paulgraham.com/superlinear.html
+---
+
 If you collected lists of techniques for doing great work in a lot of different fields, what would the intersection look like? I decided to find out by making it.
 
 Partly my goal was to create a guide that could be used by someone working in any field. But I was also curious about the shape of the intersection. And one thing this exercise shows is that it does have a definite shape; it's not just a point labelled "work hard."

--- a/data/superlinear-returns.md
+++ b/data/superlinear-returns.md
@@ -1,8 +1,14 @@
+---
+title: Superlinear Returns
+date: 2023-10
+url: https://paulgraham.com/superlinear.html
+---
+
 One of the most important things I didn't understand about the world when I was a child is the degree to which the returns for performance are superlinear.
 
 Teachers and coaches implicitly told us the returns were linear. "You get out," I heard a thousand times, "what you put in." They meant well, but this is rarely true. If your product is only half as good as your competitor's, you don't get half as many customers. You get no customers, and you go out of business.
 
-It's obviously true that the returns for performance are superlinear in business. Some think this is a flaw of capitalism, and that if we changed the rules it would stop being true. But superlinear returns for performance are a feature of the world, not an artifact of rules we've invented. We see the same pattern in fame, power, military victories, knowledge, and even benefit to humanity. In all of these, the rich get richer. 
+It's obviously true that the returns for performance are superlinear in business. Some think this is a flaw of capitalism, and that if we changed the rules it would stop being true. But superlinear returns for performance are a feature of the world, not an artifact of rules we've invented. We see the same pattern in fame, power, military victories, knowledge, and even benefit to humanity. In all of these, the rich get richer.
 
 You can't understand the world without understanding the concept of superlinear returns. And if you're ambitious you definitely should, because this will be the wave you surf on.
 
@@ -76,7 +82,7 @@ There are many variables that affect how good your work is, and if you want to b
 
 There's a surprising amount of technique to doing great work. It's not just a matter of trying hard. I'm going to take a shot giving a recipe in one paragraph.
 
-Choose work you have a natural aptitude for and a deep interest in. Develop a habit of working on your own projects; it doesn't matter what they are so long as you find them excitingly ambitious. Work as hard as you can without burning out, and this will eventually bring you to one of the frontiers of knowledge. These look smooth from a distance, but up close they're full of gaps. Notice and explore such gaps, and if you're lucky one will expand into a whole new field. Take as much risk as you can afford; if you're not failing occasionally you're probably being too conservative. Seek out the best colleagues. Develop good taste and learn from the best examples. Be honest, especially with yourself. Exercise and eat and sleep well and avoid the more dangerous drugs. When in doubt, follow your curiosity. It never lies, and it knows more than you do about what's worth paying attention to. 
+Choose work you have a natural aptitude for and a deep interest in. Develop a habit of working on your own projects; it doesn't matter what they are so long as you find them excitingly ambitious. Work as hard as you can without burning out, and this will eventually bring you to one of the frontiers of knowledge. These look smooth from a distance, but up close they're full of gaps. Notice and explore such gaps, and if you're lucky one will expand into a whole new field. Take as much risk as you can afford; if you're not failing occasionally you're probably being too conservative. Seek out the best colleagues. Develop good taste and learn from the best examples. Be honest, especially with yourself. Exercise and eat and sleep well and avoid the more dangerous drugs. When in doubt, follow your curiosity. It never lies, and it knows more than you do about what's worth paying attention to.
 
 And there is of course one other thing you need: to be lucky. Luck is always a factor, but it's even more of a factor when you're working on your own rather than as part of an organization. And though there are some valid aphorisms about luck being where preparedness meets opportunity and so on, there's also a component of true chance that you can't do anything about. The solution is to take multiple shots. Which is another reason to start taking risks early.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,16 +2,17 @@
 name = "rag-app"
 version = "0.1.0"
 description = "Your description here"
-authors = ["Jason Liu <jason@jxnl.co>","Ivan Leo <ivanleomk@gmail.com>"]
+authors = ["Jason Liu <jason@jxnl.co>", "Ivan Leo <ivanleomk@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
 openai = "^1.1.0"
 pydantic = "^2.0.2"
 typer = "^0.9.0"
-lancedb="^0.6.1"
-tqdm="^4.66.2"
+lancedb = "^0.6.1"
+tqdm = "^4.66.2"
 rich = "^13.6.0"
+python-frontmatter = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ lancedb = "^0.6.1"
 tqdm = "^4.66.2"
 rich = "^13.6.0"
 python-frontmatter = "^1.1.0"
+duckdb="0.10.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/rag_app/ingest.py
+++ b/rag_app/ingest.py
@@ -5,6 +5,10 @@ from pathlib import Path
 from typing import Iterable
 from tqdm import tqdm
 from rich import print
+import frontmatter
+import hashlib
+from datetime import datetime
+from collections import defaultdict
 
 app = typer.Typer()
 
@@ -13,7 +17,13 @@ def read_files(path: Path, file_suffix: str) -> Iterable[Document]:
     for i, file in enumerate(path.iterdir()):
         if file.suffix != file_suffix:
             continue
-        yield Document(id=i, text=file.read_text(), filename=file.name)
+        post = frontmatter.load(file)
+        yield Document(
+            id=hashlib.md5(post.content.encode("utf-8")).hexdigest(),
+            content=post.content,
+            filename=file.name,
+            metadata=post.metadata,
+        )
 
 
 def batch_chunks(chunks, batch_size=20):
@@ -31,21 +41,30 @@ def batch_chunks(chunks, batch_size=20):
 def chunk_text(
     documents: Iterable[Document], window_size: int = 1024, overlap: int = 0
 ):
-    id = 0
     for doc in documents:
         for chunk_num, start_pos in enumerate(
-            range(0, len(doc.text), window_size - overlap)
+            range(0, len(doc.content), window_size - overlap)
         ):
             # TODO: Fix up this and use a Lance Model instead - have reached out to the team to ask for some help
             yield {
-                "id": id,
                 "doc_id": doc.id,
-                "chunk_num": chunk_num,
-                "start_pos": start_pos,
-                "end_pos": start_pos + window_size,
-                "text": doc.text[start_pos : start_pos + window_size],
+                "chunk_id": chunk_num,
+                "text": doc.content[start_pos : start_pos + window_size],
+                "post_title": doc.metadata["title"],
+                "publish_date": datetime.strptime(doc.metadata["date"], "%Y-%m"),
+                "source": doc.metadata["url"],
             }
-            id += 1
+
+
+def populate_chunks_with_counts(chunks: Iterable[TextChunk]):
+    counts = defaultdict(list)
+
+    for chunk in chunks:
+        counts[chunk["doc_id"]].append(chunk)
+
+    for doc in counts.keys():
+        for chunk in counts[doc]:
+            yield {**chunk, "post_chunk_count": len(counts[doc])}
 
 
 @app.command(help="Ingest data into a given lancedb")
@@ -68,6 +87,7 @@ def from_folder(
 
     files = read_files(path, file_suffix)
     chunks = chunk_text(files)
+    chunks = populate_chunks_with_counts(chunks)
     batched_chunks = batch_chunks(chunks)
 
     ttl = 0

--- a/rag_app/ingest.py
+++ b/rag_app/ingest.py
@@ -42,16 +42,25 @@ def chunk_text(
     documents: Iterable[Document], window_size: int = 1024, overlap: int = 0
 ):
     for doc in documents:
+        assert doc.metadata[
+            "date"
+        ], "A valid date must be provided in the metadata of the markdown file to ingest."
+        try:
+            doc_publish_date = datetime.strptime(doc.metadata["date"], "%Y-%m")
+        except ValueError:
+            raise ValueError(
+                f"Date format must be YYYY-MM (Eg. 2024-10). Unable to parse provided date of {doc.metadata['date']} "
+            )
+
         for chunk_num, start_pos in enumerate(
             range(0, len(doc.content), window_size - overlap)
         ):
-            # TODO: Fix up this and use a Lance Model instead - have reached out to the team to ask for some help
             yield {
                 "doc_id": doc.id,
                 "chunk_id": chunk_num,
                 "text": doc.content[start_pos : start_pos + window_size],
                 "post_title": doc.metadata["title"],
-                "publish_date": datetime.strptime(doc.metadata["date"], "%Y-%m"),
+                "publish_date": doc_publish_date,
                 "source": doc.metadata["url"],
             }
 

--- a/rag_app/models.py
+++ b/rag_app/models.py
@@ -1,22 +1,26 @@
-from lancedb.pydantic import LanceModel, Vector
+from datetime import datetime
+from typing import List, Union
+
 from lancedb.embeddings import get_registry
+from lancedb.pydantic import LanceModel, Vector
 from pydantic import BaseModel
 
 openai = get_registry().get("openai").create(name="text-embedding-3-large", dim=256)
 
 
 class TextChunk(LanceModel):
-    id: int
-    doc_id: int
-    chunk_num: int
-    start_pos: int
-    end_pos: int
+    doc_id: str
     text: str = openai.SourceField()
-    # For some reason if we call openai.ndim(), it returns 1536 instead of 256 like we want
     vector: Vector(openai.ndims()) = openai.VectorField(default=None)
+    post_title: str
+    publish_date: datetime
+    chunk_id: int
+    post_chunk_count: int
+    source: str
 
 
 class Document(BaseModel):
-    id: int
-    text: str
+    id: str
+    content: str
     filename: str
+    metadata: dict[str, Union[str, List[str]]]

--- a/rag_app/models.py
+++ b/rag_app/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import List, Union
-
+from pydantic import field_validator
 from lancedb.embeddings import get_registry
 from lancedb.pydantic import LanceModel, Vector
 from pydantic import BaseModel
@@ -15,7 +15,6 @@ class TextChunk(LanceModel):
     post_title: str
     publish_date: datetime
     chunk_id: int
-    post_chunk_count: int
     source: str
 
 
@@ -24,3 +23,27 @@ class Document(BaseModel):
     content: str
     filename: str
     metadata: dict[str, Union[str, List[str]]]
+
+    @field_validator('metadata')
+    @classmethod
+    def metadata_must_contain_a_valid_datestring(cls, v: dict[str, Union[str, List[str]]]):
+        try:
+            datetime.strptime(v["date"], "%Y-%m")
+        except Exception as e:
+            raise ValueError(
+                f"Date format must be YYYY-MM (Eg. 2024-10). Unable to parse provided date of {v['date']} "
+            )
+
+        return v
+    
+    @field_validator('metadata')
+    @classmethod
+    def metadata_must_contain_required_keys(cls,v:dict[str, Union[str, List[str]]]):
+        required_keys = [
+            "url","date","title"
+        ]
+
+        for k in required_keys:
+            if k not in v:
+                raise ValueError(f"Required Property {k} is not present in metadata")
+        return v

--- a/rag_app/query.py
+++ b/rag_app/query.py
@@ -38,10 +38,17 @@ def db(
     )
 
     table = Table(title="Results", box=box.HEAVY, padding=(1, 2), show_lines=True)
-    table.add_column("Chunk ID", style="cyan", no_wrap=True)
     table.add_column("Result", style="magenta")
+    table.add_column("Post Title", style="green")
+    table.add_column("Chunk Number", style="yellow")
+    table.add_column("Publish Date", style="blue")
 
     for result in results:
-        table.add_row(str(result.id), textwrap.fill(result.text, width=120))
-
+        chunk_number = f"{result.chunk_id}/{result.post_chunk_count}"
+        table.add_row(
+            textwrap.fill(result.text, width=120),
+            f"{result.post_title}\n({result.source})",
+            chunk_number,
+            result.publish_date.strftime("%Y-%m-%d"),
+        )
     Console().print(table)

--- a/rag_app/query.py
+++ b/rag_app/query.py
@@ -49,6 +49,6 @@ def db(
             textwrap.fill(result.text, width=120),
             f"{result.post_title}\n({result.source})",
             chunk_number,
-            result.publish_date.strftime("%Y-%m-%d"),
+            result.publish_date.strftime("%Y-%m"),
         )
     Console().print(table)

--- a/rag_app/query.py
+++ b/rag_app/query.py
@@ -38,16 +38,16 @@ def db(
     )
 
     table = Table(title="Results", box=box.HEAVY, padding=(1, 2), show_lines=True)
-    table.add_column("Result", style="magenta")
-    table.add_column("Post Title", style="green")
+    table.add_column("Post Title", style="green", max_width=30)
+    table.add_column("Content", style="magenta", max_width=120)
     table.add_column("Chunk Number", style="yellow")
     table.add_column("Publish Date", style="blue")
 
     for result in results:
         chunk_number = f"{result.chunk_id}/{result.post_chunk_count}"
         table.add_row(
-            textwrap.fill(result.text, width=120),
-            f"{result.post_title}\n({result.source})",
+            f"{result.post_title}({result.source})",
+            result.text,
             chunk_number,
             result.publish_date.strftime("%Y-%m"),
         )

--- a/rag_app/query.py
+++ b/rag_app/query.py
@@ -36,7 +36,7 @@ def db(
     results: List[TextChunk] = (
         table.search(query_vector).limit(n).to_pydantic(TextChunk)
     )
-
+    
     table = Table(title="Results", box=box.HEAVY, padding=(1, 2), show_lines=True)
     table.add_column("Post Title", style="green", max_width=30)
     table.add_column("Content", style="magenta", max_width=120)
@@ -44,7 +44,7 @@ def db(
     table.add_column("Publish Date", style="blue")
 
     for result in results:
-        chunk_number = f"{result.chunk_id}/{result.post_chunk_count}"
+        chunk_number = f"{result.chunk_id}"
         table.add_row(
             f"{result.post_title}({result.source})",
             result.text,


### PR DESCRIPTION
Adding a new PR to help introduce the use of python-frontmatter so that we can parse some metadata from the article. `query` cli command now introduces some additional fields such as post title , chunk number and the publish date of the original article.

![Screenshot 2024-03-10 at 7 11 31 PM](https://github.com/jxnl/n-levels-of-rag/assets/45760326/1fba5b42-f597-4361-b94d-685f584b6002)


<!--
ELLIPSIS_HIDDEN
-->
----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 73004b848d69c202d1294eab979402160a76c370.  | 
|--------|--------|

### Summary:
This PR introduces the use of `python-frontmatter` for metadata parsing, updates various functions to include this metadata, and modifies markdown files to include frontmatter metadata.

**Key points**:
- Introduced `python-frontmatter` for metadata parsing.
- Updated `ingest.py` to include metadata in `Document` object and chunks.
- Updated `Document` and `TextChunk` models in `models.py` to include new fields.
- Updated `query.py` to display additional metadata and changed date format.
- Modified markdown files in `data` directory to include frontmatter metadata.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
