### PR TITLE
Implemented chunking using unstructured

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ tqdm = "^4.66.2"
 rich = "^13.6.0"
 python-frontmatter = "^1.1.0"
 duckdb="0.10.0"
+unstructured="0.12.6"
 
 [tool.poetry.dev-dependencies]
 

--- a/rag_app/ingest.py
+++ b/rag_app/ingest.py
@@ -8,7 +8,7 @@ from rich import print
 import frontmatter
 import hashlib
 from datetime import datetime
-from collections import defaultdict
+from unstructured.partition.text import partition_text
 
 app = typer.Typer()
 
@@ -42,13 +42,11 @@ def chunk_text(
     documents: Iterable[Document], window_size: int = 1024, overlap: int = 0
 ):
     for doc in documents:
-        for chunk_num, start_pos in enumerate(
-            range(0, len(doc.content), window_size - overlap)
-        ):
+        for chunk_num, chunk in enumerate(partition_text(text=doc.content)):
             yield {
                 "doc_id": doc.id,
-                "chunk_id": chunk_num+1,
-                "text": doc.content[start_pos : start_pos + window_size],
+                "chunk_id": chunk_num + 1,
+                "text": chunk.text,
                 "post_title": doc.metadata["title"],
                 "publish_date": datetime.strptime(doc.metadata["date"], "%Y-%m"),
                 "source": doc.metadata["url"],


### PR DESCRIPTION
Since our text doesn't have complex structures, I opted for the simplest implementation -> using just the newlines to split the chunks itself. Chunks seem a lot nicer as a result

<!--
ELLIPSIS_HIDDEN
-->
----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 66cbf0931963d24db93deb4f3e0d88b9d0c94350.  | 
|--------|--------|

### Summary:
This PR simplifies the text chunking process by replacing the sliding window approach with a newline-based method.

**Key points**:
- Simplified the text chunking process in `rag_app/ingest.py`.
- Replaced sliding window chunking with `partition_text` function from `unstructured.partition.text`.
- Chunks are now split based on newlines.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
